### PR TITLE
Acc corrupted messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -319,7 +319,7 @@ class StreamConsumer {
 
   protected async processMessage<T>(id: string, message: string[]) {
     if (!message || !Array.isArray(message) || message.length < 2) {
-      return this.logger.fatal('Error while parsing message. Corrupted message.', id, message);
+      return this.logger.error('Error while parsing message. Corrupted stream message.', id, message);
     }
     const [event, value] = message;
     const eventObj: IEvent<T> = JSON.parse(value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,6 +318,9 @@ class StreamConsumer {
   }
 
   protected async processMessage<T>(id: string, message: string[]) {
+    if (!message || !Array.isArray(message) || message.length < 2) {
+      return this.logger.fatal(' Error while parsing message. Corrupted message.', id, message);
+    }
     const [event, value] = message;
     const eventObj: IEvent<T> = JSON.parse(value);
     return this.processEvent(id, event, eventObj)

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,7 +319,7 @@ class StreamConsumer {
 
   protected async processMessage<T>(id: string, message: string[]) {
     if (!message || !Array.isArray(message) || message.length < 2) {
-      return this.logger.fatal(' Error while parsing message. Corrupted message.', id, message);
+      return this.logger.fatal('Error while parsing message. Corrupted message.', id, message);
     }
     const [event, value] = message;
     const eventObj: IEvent<T> = JSON.parse(value);


### PR DESCRIPTION
skip messages that can't be parsed to `event` and `value`.